### PR TITLE
Add info scope on account linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ However, here are a few points of attention:
         * For `Access Token URI` field use https://api.amazon.com/auth/o2/token
         * For `Client ID` field use value for LWA Security Profile
         * For `Your Secret` field use value from LWA Security Profile
+        * For `Scope` field use profile
 
     * You shall whitelist the `Alexa Redirect URLs` listed on the Account Linking page in your OAUTH service. Typically, for LWA, it means going back in the [LWA Section of the Developer Portal](https://developer.amazon.com/loginwithamazon/console/site/lwa/overview.html), select your `Security Profile`, go to the `Web Settings` and update the `Allowed Return URLs` by clicking the `Edit` button. You should have 3 URLs to add and they shall look like the following ones:
 ```


### PR DESCRIPTION
On this documentation https://images-na.ssl-images-amazon.com/images/G/01/lwa/dev/docs/website-developer-guide._TTH_.pdf we have multiple scope to get user's info.

When creating linking account on alexa skill developer webpage, we need to define a scope. 
The **profile** scope seems to work perfectly for this example and is missing on this documentation.